### PR TITLE
Fix bungee.yml

### DIFF
--- a/src/main/resources/bungee.yml
+++ b/src/main/resources/bungee.yml
@@ -1,4 +1,4 @@
 name: StaffChat
-authors: [oskar3123]
+author: oskar3123
 main: me.oskar3123.staffchat.bungee.BungeeMain
 version: 1.3.0


### PR DESCRIPTION
Quick fix for having the author displayed as null due to an invalid bungee.yml. This could prevent the plugin from being loaded through external Bungee plugin managers :)